### PR TITLE
Use WP Core screen-reader-text over hide-text

### DIFF
--- a/_component/readmore/_notes.md
+++ b/_component/readmore/_notes.md
@@ -1,6 +1,6 @@
 Ideally your link text should be descriptive enough to stand alone. Links like "click here", "learn more", "continue reading", and "read more"
 are only helpful within the context of the content. but when screen readers extract all links from a page from easy navigation you end with a lot of links that don't say anything about where they go (very unhelpful, right?).
 
-However, if you must use a link that says, "read more," this is how you can do it in an accessible way.
+However, if you must use a link that says, "read more", this is how you can do it in an accessible way.
 
 With whatever class you use to hide the "read more" overflow text it's important to make sure you're not using display: none, because it will remove the content from screen readers, making this exercise kinda useless.

--- a/_component/readmore/component.css
+++ b/_component/readmore/component.css
@@ -3,12 +3,11 @@
   visibility: hidden; or display: none; because
   it will hide the text from a screenreader
 */
-.hide-text {
-  position: absolute;
-  left: -99em;
-  width: 1px;
+.screen-reader-text {
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
   height: 1px;
-  top: auto;
+  width: 1px;
   overflow: hidden; }
 
 /*# sourceMappingURL=readmore.css.map */

--- a/_component/readmore/component.html
+++ b/_component/readmore/component.html
@@ -2,6 +2,6 @@
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   Ut aliquet suscipit rhoncus. Donec ornare, dolor a
   dignissim pretium, arcu sapien pretium neque, non pharetra arcu magna
-  nec turpis. <a href="#!">Read more <span class="hide-text">about
+  nec turpis. <a href="#!">Read more <span class="screen-reader-text">about
   an interesting article to read</span></a>
 </p>

--- a/_component/readmore/example.html
+++ b/_component/readmore/example.html
@@ -20,7 +20,7 @@
 	      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	      Ut aliquet suscipit rhoncus. Donec ornare, dolor a
 	      dignissim pretium, arcu sapien pretium neque, non pharetra arcu magna
-	      nec turpis. <a href="#!">Read more <span class="hide-text">about
+	      nec turpis. <a href="#!">Read more <span class="screen-reader-text">about
 		  an interesting article to read</span></a>
 	   </p>
 

--- a/_component/readmore/scss/component.scss
+++ b/_component/readmore/scss/component.scss
@@ -6,11 +6,10 @@
   it will hide the text from a screenreader
 */
 
-.hide-text {
-  position: absolute;
-  left: -99em;
-  width: 1px;
-  height: 1px;
-  top: auto;
-  overflow: hidden;
+.screen-reader-text {
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
 }


### PR DESCRIPTION
Just wanted to keep consistent with https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/
