### PR TITLE
Add basic iframe styles to example.html head

### DIFF
--- a/_component/menu-dropdown/example.html
+++ b/_component/menu-dropdown/example.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <title>Menu - Dropdown</title>
   <link rel="stylesheet" href="component.css">
+  <style>
+    * { font-family:  sans-serif;}
+    a { color:  #333; }
+    a:hover { color:  #444; }
+    .site-menu-toggle { text-transform:  uppercase; text-decoration: none; }
+  </style>
 </head>
 <body>
   <header class="site-header" role="banner" itemscope="itemscope" itemtype="http://schema.org/WPHeader">


### PR DESCRIPTION
Wondering how people feel about adding some ultra minimal styles to the iFrame examples. Talking about some slightly less browser default styles. 

There's just one example in this commit (screenshot below). If that's something that looks like it'd be of value, I can do some of the others. If not, then we've only wasted 4 lines of css, and one commit.  

https://dl.dropboxusercontent.com/s/to8bwbidyawlv77/2016-09-14%20at%209.21%20PM.png
