### PR TITLE
Ensure correct toggling on aria-expanded and aria-selected

### DIFF
--- a/_component/accordion/component.js
+++ b/_component/accordion/component.js
@@ -39,7 +39,7 @@
 				nextPanel.querySelector( '.accordion-label' ).setAttribute( 'tabindex', -1 );
 				nextPanel.querySelector( '.accordion-label' ).focus();
 
-				if ( ! nextPanel.classList.contains( 'visually-hidden' ) ) {
+				if ( nextPanel.classList.contains( 'is-active' ) ) {
 
 					head.setAttribute( 'aria-selected', 'true' );
 					head.setAttribute( 'aria-expanded', 'true' );


### PR DESCRIPTION
Adjust conditional logic so that aria-expanded, and aria-selected attributes on the accordion header are correctly toggled when selected.

Addresses #84 
