### PR TITLE
Micro optimizations/accordian

### DIFF
--- a/_component/accordion/component.js
+++ b/_component/accordion/component.js
@@ -4,7 +4,7 @@
 	var accordion = document.getElementsByClassName( 'accordion' );
 
 	var forEach = function( array, callback, scope ) {
-		for ( var i = 0; i < array.length; i++ ) {
+		for ( var i = 0, imax = array.length; i < imax; i++ ) {
 			callback.call( scope, i, array[i] ); // passes back stuff we need
 		}
 	};


### PR DESCRIPTION
- `getElementsByClassName` is [much faster](https://internal.10up.com/blog/2016/05/31/jquery-1-x-vs-jquery-2-x/) than `querySelectorAll`.
- `addEventListener` is [more flexible](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Why_use_addEventListener) than `onclick`.
- The `accordion-label` element should be assigned to a variable rather than selected twice.
- In the for loop, the array length should be assigned to a variable, rather than being calculated on each loop iteration.
