### PR TITLE
Social Links <section> & content

### DIFF
--- a/_component/social-links/component.html
+++ b/_component/social-links/component.html
@@ -1,32 +1,33 @@
 <div class="social-links">
 	<ul class="social-links__list">
 		<li class="social-links__item">
-			<a href="https://www.facebook.com/sharer/sharer.php?u={{ theurl }}&t={{ thetitle }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+			<a href="https://www.facebook.com/sharer/sharer.php?u=http://google.com&t=Google" target="_blank" rel="noopener noreferrer" class="social-links__link">
 				<span class="social-links__text">
 					Share on Facebook <span class="sr-text">(opens new window)</span>
 				</span>
 			</a>
 		</li>
 		<li class="social-links__item">
-			<a href="https://twitter.com/share?text=TweetText&url=http://google.com" target="_blank" rel="noopener noreferrer" class="social-links__link">
+			<a href="https://twitter.com/share?text=Google&url=http://google.com" target="_blank" rel="noopener noreferrer" class="social-links__link">
 				<span class="social-links__text">
 					Share on Twitter  <span class="sr-text">(opens new window)</span>
 				</span>
+
 			</a>
 		</li>
 		<li class="social-links__item">
-			<a href="https://www.linkedin.com/shareArticle?mini=true&url={{ theurl }}&title={{ thetitle }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+			<a href="https://www.linkedin.com/shareArticle?mini=true&url=http://google.com&title=Google" target="_blank" rel="noopener noreferrer" class="social-links__link">
 				<span class="social-links__text">
 					Share on LinkedIn  <span class="sr-text">(opens new window)</span>
 				</span>
 			</a>
 		</li>
 		<li class="social-links__item">
-			<a href="http://www.pinterest.com/pin/create/bookmarklet/?url={{ theurl }}&media={{ mediatype }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+			<a href="http://www.pinterest.com/pin/create/bookmarklet/?url=http://google.com&media={{ mediatype }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
 				<span class="social-links__text">
 					Share on Pinterest <span class="sr-text">(opens new window)</span>
 				</span>
 			</a>
 		</li>
 	</ul>
-</div><!--/.links__share-->
+</div><!--/.social-links-->

--- a/_component/social-links/example.html
+++ b/_component/social-links/example.html
@@ -17,14 +17,14 @@
 		<div class="social-links">
 			<ul class="social-links__list">
 				<li class="social-links__item">
-					<a href="https://www.facebook.com/sharer/sharer.php?u={{ theurl }}&t={{ thetitle }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+					<a href="https://www.facebook.com/sharer/sharer.php?u=http://google.com&t=Google" target="_blank" rel="noopener noreferrer" class="social-links__link">
 						<span class="social-links__text">
 							Share on Facebook <span class="sr-text">(opens new window)</span>
 						</span>
 					</a>
 				</li>
 				<li class="social-links__item">
-					<a href="https://twitter.com/share?text={{ thetext }}&url={{ theurl }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+					<a href="https://twitter.com/share?text=Google&url=http://google.com" target="_blank" rel="noopener noreferrer" class="social-links__link">
 						<span class="social-links__text">
 							Share on Twitter  <span class="sr-text">(opens new window)</span>
 						</span>
@@ -32,21 +32,21 @@
 					</a>
 				</li>
 				<li class="social-links__item">
-					<a href="https://www.linkedin.com/shareArticle?mini=true&url={{ theurl }}&title={{ thetitle }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+					<a href="https://www.linkedin.com/shareArticle?mini=true&url=http://google.com&title=Google" target="_blank" rel="noopener noreferrer" class="social-links__link">
 						<span class="social-links__text">
 							Share on LinkedIn  <span class="sr-text">(opens new window)</span>
 						</span>
 					</a>
 				</li>
 				<li class="social-links__item">
-					<a href="http://www.pinterest.com/pin/create/bookmarklet/?url={{ theurl }}&media={{ mediatype }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
+					<a href="http://www.pinterest.com/pin/create/bookmarklet/?url=http://google.com&media={{ mediatype }}" target="_blank" rel="noopener noreferrer" class="social-links__link">
 						<span class="social-links__text">
 							Share on Pinterest <span class="sr-text">(opens new window)</span>
 						</span>
 					</a>
 				</li>
 			</ul>
-		</div><!--/.links__share-->
+		</div><!--/.social-links-->
 
 		<script src="component.js"></script>
 		<script src="component-usage.js"></script>


### PR DESCRIPTION
Updated `<section>` to `<div>` and added real content to sharing examples so Facebook wouldn't error out.

**Issue**: https://github.com/10up/wp-component-library/issues/119
**Issue**: https://github.com/10up/wp-component-library/issues/112
