### PR TITLE
Fixed “Download SCSS” link styling and minor typo fix

### DIFF
--- a/_component/readmore/_notes.md
+++ b/_component/readmore/_notes.md
@@ -1,5 +1,5 @@
 Ideally your link text should be descriptive enough to stand alone. Links like "click here", "learn more", "continue reading", and "read more"
-are only helpful within the context of the content. but when screen readers extract all links from a page for easy navigation you end up with a lot of links that don't say anything about where they go (very unhelpful, right?).
+are only helpful within the context of the content. But when screen readers extract all links from a page for easy navigation you end up with a lot of links that don't say anything about where they go (very unhelpful, right?).
 
 However, if you must use a link that says, "read more", this is how you can do it in an accessible way.
 

--- a/_component/readmore/index.md
+++ b/_component/readmore/index.md
@@ -18,7 +18,8 @@ category: content
 ```html
 {% include_relative component.html %}
 ```
-<h3>SCSS <a href="scss/component.scss" target="_blank">Download SCSS</a></h3>
+
+<h3>SCSS <span class="link"><a href="scss/component.scss" target="_blank">Download SCSS</a></span></h3>
 
 ```scss
 {% include_relative scss/component.scss %}


### PR DESCRIPTION
Link: https://10up.github.io/wp-component-library/component/readmore/index.html

Download SCSS doesn't have correct styling and fixed a minor typo.
