### PR TITLE
Blogroll: Close span tags.

### DIFF
--- a/_component/blogroll/component.html
+++ b/_component/blogroll/component.html
@@ -33,7 +33,7 @@
 		<!-- A description of the post content - the excerpt -->
 		<div itemprop="description">
 			<p>This would be the "description" or the excerpt of the blog post content.</p>
-			<a href="http://www.example.com/" itemprop="url">Read More... <span class="screen-reader-text">Post Title<span></a>
+			<a href="http://www.example.com/" itemprop="url">Read More... <span class="screen-reader-text">Post Title</span></a>
 		</div><!--/itemprop=description-->
 
 	</article><!--/itemtype=BlogPosting-->

--- a/_component/blogroll/example.html
+++ b/_component/blogroll/example.html
@@ -50,7 +50,7 @@
                 <!-- A description of the post content - the excerpt -->
                 <div itemprop="description">
                     <p>This would be the "description" or the excerpt of the blog post content.</p>
-                    <a href="http://www.example.com/" itemprop="url">Read More... <span class="screen-reader-text">Post Title<span></a>
+                    <a href="http://www.example.com/" itemprop="url">Read More... <span class="screen-reader-text">Post Title</span></a>
                 </div>
 
             </article><!--/itemtype=BlogPosting-->


### PR DESCRIPTION
Hi there,

in the _blogroll_ component, there were two incorrectly (i.e., not) closed `span` tags.