### PR TITLE
Removed duplicate padding declarations for tab-item link

### DIFF
--- a/_component/tabs/component.css
+++ b/_component/tabs/component.css
@@ -11,9 +11,8 @@
   .tab-item > a {
     border: 1px solid #777;
     display: inline-block;
-    padding: 10px 15px;
-    text-decoration: none;
-    padding: 5px 8px; }
+    padding: 5px 8px;
+    text-decoration: none; }
     @media (min-width: 40.625em) {
       .tab-item > a {
         padding: 10px 15px; } }

--- a/_component/tabs/scss/component.scss
+++ b/_component/tabs/scss/component.scss
@@ -24,9 +24,8 @@ $color-white: #fff !default;
 	> a {
 		border: 1px solid $color-gray;
 		display: inline-block;
-		padding: 10px 15px;
-		text-decoration: none;
 		padding: 5px 8px;
+		text-decoration: none;
 
 		@media ( min-width: $bp-small ) {
 			padding: 10px 15px;


### PR DESCRIPTION
Used this component on a project earlier today and noticed a duplicate padding declarations for the tab-item link tag. This PR removes it.