### PR TITLE
Add PR template from 10up oss format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+### Requirements
+
+Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
+-->
+
+### Description of the Change
+
+<!--
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected. -->
+
+### Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+What process did you follow to verify that your change has the desired effects?
+
+- How did you verify that all new functionality works as expected?
+- How did you verify that all changed functionality works as expected?
+- How did you verify that the change has not introduced any regressions?
+
+Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
+-->
+
+### Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] All new and existing tests passed.
+
+<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->


### PR DESCRIPTION
The PR does what it says it does, though we'll probably want to move the issue templates from #190 into the .github directory (sorry I didn't do that myself, you can scold me later).