### PR TITLE
if there is no iframe on the component page, do not try to add the rw…

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,6 +49,10 @@
 			  	component = components[i];
 			  	iframe = component.querySelector( 'iframe' );
 
+			  	if ( !iframe ) {
+			  		return;
+			  	}
+
 			  	// Create the wrapper
 			  	wrapper = doc.createElement( 'div' );
 			  	wrapper.setAttribute( 'class', 'wrapper-iframe' );


### PR DESCRIPTION
…d buttons

### Description of the Change

Fix the JS error causing the menu to break only on this page; https://10up.github.io/wp-component-library/component/modal/index.html

### Verification Process

Tested the modal page (no iframe) locally as well as the accordion page (has iframe)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
