### PR TITLE
Fix schema error for breadcrumbs component

### DIFF
--- a/_component/breadcrumbs/component.html
+++ b/_component/breadcrumbs/component.html
@@ -3,7 +3,7 @@
 	<ol itemscope itemtype="http://schema.org/BreadcrumbList" aria-label="breadcrumb navigation">
 
 		<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-			<a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="https://example.com/books">
+			<a itemprop="item" href="https://example.com/books">
 
 				<!-- the actual display name of the breadcrumb -->
 				<span itemprop="name">Books</span>
@@ -17,7 +17,7 @@
 		</li>
 
 		<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-			<a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="https://example.com/books/the-book" title="You are here">
+			<a itemprop="item" href="https://example.com/books/the-book" title="You are here">
 
 				<!-- the actual display name of the breadcrumb -->
 				<span itemprop="name">Subtopic or landing page</span>

--- a/_component/breadcrumbs/example.html
+++ b/_component/breadcrumbs/example.html
@@ -19,7 +19,7 @@
 		<ol itemscope itemtype="http://schema.org/BreadcrumbList" aria-label="breadcrumb navigation">
 
 			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="https://example.com/books">
+				<a itemprop="item" href="https://example.com/books">
 
 					<!-- the actual display name of the breadcrumb -->
 					<span itemprop="name">Books</span>
@@ -33,7 +33,7 @@
 			</li>
 
 			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="https://example.com/books/the-book" title="You are here">
+				<a itemprop="item" href="https://example.com/books/the-book" title="You are here">
 
 					<!-- the actual display name of the breadcrumb -->
 					<span itemprop="name">Subtopic or landing page</span>


### PR DESCRIPTION
This PR fixes https://github.com/10up/wp-component-library/issues/207.

`itemscope itemtype="http://schema.org/Thing" ` on the links were causing the issue and this PR removed them. This fix can be validated using https://search.google.com/structured-data/testing-tool and here is a screenshot:

<img width="1552" alt="Screen Shot 2019-10-14 at 9 01 34 PM" src="https://user-images.githubusercontent.com/2092765/66792233-d1f56880-eec5-11e9-94e3-19f5d5428744.png">

Reference: https://schema.org/BreadcrumbList
<img width="1394" alt="Screen Shot 2019-10-14 at 9 08 55 PM" src="https://user-images.githubusercontent.com/2092765/66792490-f1d95c00-eec6-11e9-9222-47e96d8520ba.png">

