### PR TITLE
Fix trailing slash 404s, repo URL, and capital_H_dangit

### DIFF
--- a/_component/datepicker/content/_resources.md
+++ b/_component/datepicker/content/_resources.md
@@ -1,4 +1,4 @@
 <ul>
 	<li><a href="https://dbushell.github.io/Pikaday/">Pikaday</a></li>
-	<li><a href="https://github.com/dbushell/Pikaday">Pikaday on Github</a></li>
+	<li><a href="https://github.com/dbushell/Pikaday">Pikaday on GitHub</a></li>
 </ul>

--- a/contributing.md
+++ b/contributing.md
@@ -11,7 +11,7 @@ category: contributing
 	</p>
 </div>
 
-We don't know everything! We welcome pull requests and spirited, but respectful, debates. Please contribute via [pull requests on GitHub](https://github.com/10up/component-library/pulls).
+We don't know everything! We welcome pull requests and spirited, but respectful, debates. Please contribute via [pull requests on GitHub](https://github.com/10up/wp-component-library/pulls).
 
 All contributions to the component library should be tested against version 2.1 of the Web Accessibility Content Guidelines ([WCAG 2.1](https://www.w3.org/TR/WCAG21/))
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -15,7 +15,7 @@ category: documentation
 <p>
 This page will walk you through how to set up this documentation site
 locally and contribute to it moving forward. If you'd like to contribute to a component
-please read through our <a href="{{ site.baseurl }}/contributing/">contributing guidelines</a>.
+please read through our <a href="{{ site.baseurl }}/contributing">contributing guidelines</a>.
 </p>
 
 ## Dependencies
@@ -63,4 +63,4 @@ Once `bundle exec jekyll serve` has run, you can view the 10up Component library
 Server address: http://127.0.0.1:4000/wp-component-library/
 Server running... press ctrl-c to stop.</code></pre>
 
-Check out Github's documentation on [local Jekyll setup](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#step-4-build-your-local-jekyll-site) for more info.
+Check out GitHub's documentation on [local Jekyll setup](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#step-4-build-your-local-jekyll-site) for more info.

--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ category: home
 	<h2>Have an idea for a new component?</h2>
 	<ul class="u-max-width--none list-inline list-clean">
 		<li>
-			<a href="{{ site.baseurl }}/contributing/" class="button button--secondary">
+			<a href="{{ site.baseurl }}/contributing" class="button button--secondary">
 				Contribute
 			</a>
 		</li>


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Some minor fixes from me to prevent 404s and ending up in the wrong repo, as well as a little bit of WordPress-style treatment for the GitHub name :)

### Alternate Designs

n/a

### Benefits

More beauty in the world

### Possible Drawbacks

An annoying branch name from yours truly

### Verification Process

I did not build this locally so... reviewing a `git diff`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a
