### PR TITLE
Modal: Recommend using <div> instead of <dialog> due to chrome bug

### DIFF
--- a/_component/modal/component.html
+++ b/_component/modal/component.html
@@ -1,9 +1,11 @@
 <div id="my-accessible-dialog">
   <div tabindex="-1" data-a11y-dialog-hide></div>
-  <dialog aria-labelledby="dialog-title">
+	<!-- Using <div role="dialog"> instead of <dialog> due to chrome a bug. -->
+	<!-- https://github.com/edenspiekermann/a11y-dialog/issues/89#issuecomment-426983208 -->
+  <div role="dialog" aria-labelledby="dialog-title">
     <button type="button" data-a11y-dialog-hide aria-label="Close this dialog window">
       &times;
     </button>
     <h1 id="dialog-title">Dialog Title</h1>
-  </dialog>
+  </div>
 </div>

--- a/_component/modal/content/_notes.md
+++ b/_component/modal/content/_notes.md
@@ -4,8 +4,11 @@ an exhaustive search for a third party plugin that met all of our accessibility
 and implementation requirements, we were able to settle on using
 <a href="https://github.com/edenspiekermann/a11y-dialog">A11yDialog</a>. This
 plugin is fully WCAG 2.1 compliant, lightweight, has a robust API, no
-dependencies, leverages the native `<dialog>` element, and properly manages
-focus.
+dependencies, and properly manages focus.
+
+<strong>NOTE:</strong>
+Due to a <a href="https://github.com/edenspiekermann/a11y-dialog/issues/89#issuecomment-426983208">current bug in Chrome</a> , we recommend using `<div role="dialog">` (or `<div role="alertdialog">` to <a href="https://github.com/edenspiekermann/a11y-dialog#usage-as-a-modal">make it behave like a modal</a>) rather than leveraging the native `<dialog>` element. The bug: when clicking outside the `<dialog>` in Chrome, it does not close as expected.
+
 
 It also has <a href="https://github.com/HugoGiraudel/react-a11y-dialog">React</a>
 and <a href="https://github.com/morkro/vue-a11y-dialog">Vue</a> versions we can


### PR DESCRIPTION
### Description of the Change
- Fixes https://github.com/10up/wp-component-library/issues/221
- Resolve bug with chrome and the `<dialog>` element: https://github.com/edenspiekermann/a11y-dialog/issues/89#issuecomment-426983208
- Update notes with explanation of issue and recommendation
- Update component output with utilization of <div> and comments to explain reason

### Benefits

Prevent users from using code that fails on Chrome.

### Possible Drawbacks

Will have to revert language / updates when bug is fixed on Chrome

### Verification Process

Using this method on other projects successfully. 

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed. - NOT sure what tests to run are
