### PR TITLE
Underline all links, except in the navigation and component group

### DIFF
--- a/assets/css/sass/base/_typography.scss
+++ b/assets/css/sass/base/_typography.scss
@@ -86,14 +86,13 @@ dl {
 a {
 	color: $color-secondary;
 	font-weight: $font-weight-medium;
-	text-decoration: none;
-
-	&:hover,
-	&:focus {
-		text-decoration: underline;
-	}
+	text-decoration: underline;
 
 	abbr {
+		text-decoration: none;
+	}
+	
+	.c-nav & {
 		text-decoration: none;
 	}
 }

--- a/assets/css/sass/components/_component-group.scss
+++ b/assets/css/sass/components/_component-group.scss
@@ -22,6 +22,12 @@
 
 	a {
 		color: $color-primary;
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
 	}
 
 	sup {


### PR DESCRIPTION
The link color makes it all but impossible to discern links in the page content for people with some color vision issues. Let's just underline 'em?